### PR TITLE
Support for Decoding AIS Messages Which Span Multiple NMEA Sentences

### DIFF
--- a/encoder/lib/GG-AisDecode.js
+++ b/encoder/lib/GG-AisDecode.js
@@ -159,22 +159,12 @@ var VESSEL_TYPE= {
 
 // Ais payload is represented in a 6bits encoded string !(
 // This method is a direct transcription in nodejs of C++ ais-decoder code
-function AisDecode (input) {
+function AisDecode (input, session) {
     this.bitarray=[];
     this.valid= false; // will move to 'true' if parsing succeed
     var nmea = "";
 
     var inputtype = Object.prototype.toString.call(input);
-
-    // Require a string or an array. Turn string into an array. Return for
-    // anything else.
-    if(inputtype === "[object String]") {
-      input = [input];
-    } else if(inputtype !== "[object Array]") {
-      return;
-    }
-
-    console.log(input);
 
     this.length = 0;
 

--- a/encoder/test/AisEncodeDecodeTest.js
+++ b/encoder/test/AisEncodeDecodeTest.js
@@ -149,7 +149,7 @@ AisEncodeDecodeTest.prototype.CheckDecode = function () {
 
         // Require a string or an array. Turn string into an array. Return for
         // anything else.
-        if(aisTest.nmea instanceof Array) {
+        if(aisTest.nmea instanceof Object) {
             var session=new DummySession ();
             var aisDecoded = new AisDecode(aisTest.nmea[0], session);
             var aisDecoded = new AisDecode(aisTest.nmea[1], session);

--- a/encoder/test/AisEncodeDecodeTest.js
+++ b/encoder/test/AisEncodeDecodeTest.js
@@ -145,8 +145,6 @@ AisEncodeDecodeTest.prototype.CheckDecode = function () {
     for (var test in this.testSet) {
         var aisTest     = this.testSet [test];
 
-        var inputtype = Object.prototype.toString.call(input);
-
         // Require a string or an array. Turn string into an array. Return for
         // anything else.
         if(aisTest.nmea instanceof Object) {

--- a/encoder/test/AisEncodeDecodeTest.js
+++ b/encoder/test/AisEncodeDecodeTest.js
@@ -143,7 +143,17 @@ AisEncodeDecodeTest.prototype.CheckDecode = function () {
 
 
 
-        var aisDecoded  = new AisDecode (aisTest.nmea);
+        var inputtype = Object.prototype.toString.call(input);
+
+        // Require a string or an array. Turn string into an array. Return for
+        // anything else.
+        if(aisTest.nmea instanceof Array) {
+            var session=[];
+            var aisDecoded = new AisDecode(aisTest.nmea[0], session);
+            var aisDecoded = new AisDecode(aisTest.nmea[1], session);
+        } else {
+            var aisDecoded = new AisDecode(aisTest.nmea);
+        }
 
         if (aisDecoded.valid !== true) {
             console.log ("[%s] invalid AIS payload", test);

--- a/encoder/test/AisEncodeDecodeTest.js
+++ b/encoder/test/AisEncodeDecodeTest.js
@@ -137,18 +137,20 @@ AisEncodeDecodeTest.prototype.CheckResult = function (test, aisin, aisout, contr
 
 AisEncodeDecodeTest.prototype.CheckDecode = function () {
 
+    function DummySession () {
+        // this is a fake session for multipart AIS messages
+    }
+
     // make sure we get expected output from reference messages
     for (var test in this.testSet) {
         var aisTest     = this.testSet [test];
-
-
 
         var inputtype = Object.prototype.toString.call(input);
 
         // Require a string or an array. Turn string into an array. Return for
         // anything else.
         if(aisTest.nmea instanceof Array) {
-            var session=[];
+            var session=new DummySession ();
             var aisDecoded = new AisDecode(aisTest.nmea[0], session);
             var aisDecoded = new AisDecode(aisTest.nmea[1], session);
         } else {

--- a/encoder/test/AisEncodeDecodeTest.js
+++ b/encoder/test/AisEncodeDecodeTest.js
@@ -91,6 +91,27 @@ function AisEncodeDecodeTest (args) {
         draught    : 12.2
         //destination: "NEW YORK  " Extention message not implemented
     }
+    ,msg5_2: { // class A static info
+        aistype    : 5,
+        nmea       : ["!AIVDM,2,1,1,A,53P;lSh2ANCO8=0s<01<B0<Q8U=@Tp400000000O1@:6340Ht7`0000000000,0*29",
+                      "!AIVDM,2,2,1,A,0000000008,2*1D"],
+        mmsi       : 235074703,
+        imo        : 12894435639,
+        callsign   : "2CPN3",
+        shipname   : "SD CHRISTINA",
+        cargo      : 31,
+        dimA       : 10,
+        dimB       : 10,
+        dimC       :  6,
+        dimD       :  3,
+        fixaistype :  1,
+        etamn      : 60,
+        etaho      : 24,
+        etaday     :  0,
+        etamonth   :  0,
+        draught    :  3
+        //destination: "NEW YORK  " Extention message not implemented
+    }
 }}
 
 // compare input with decoded outputs

--- a/smsc/package.json
+++ b/smsc/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "ggsmsc",
   "description" : "GTSdtracking is an opensource GPS tracking server framework",
-  "version" : "0.1.6",
+  "version" : "0.1.7",
   "author" : {
     "name" : "Fulup Ar Foll",
     "email" : "fulup@breizhme.net",


### PR DESCRIPTION
Attempt to address issue #4.

In order to make sure we don't break the existing GeoGate API, AisDecode
checks the type of it's input parameter. If it is passed a string, it
behaves as before.

If AisDecode is passed an array instead of a string, it will assume that
the sentences in the array make up the multiple parts of a NMEA encoded
AIS message.

The sentences in the array must be in order, must be the complete set
required to reassemble the AIS message and must correspond to no more
than one AIS message. It is the responsibility of the caller to ensure
these constraints are met.