### PR TITLE
Allow own ship AIS signals

### DIFF
--- a/encoder/lib/GG-AisDecode.js
+++ b/encoder/lib/GG-AisDecode.js
@@ -172,7 +172,8 @@ function AisDecode (input, session) {
     var nmea = input.split (",");
 
     // make sure we are facing a supported AIS message
-    if (nmea [0] !== '!AIVDM') return;
+    // AIVDM for standard messages, AIVDO for messages from own ship AIS
+    if (nmea[0] !== '!AIVDM' || nmea[0] !== '!AIVDO') return;
 
     // the input string is part of a multipart message, make sure we were
     // passed a session object.


### PR DESCRIPTION
When plugged into a ship AIS, it will indicate own ship by sending AIVDO messages instead of AIVDM.