### PR TITLE
fix nmea longitude - pad degrees to 3 digits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ nbproject/private/
 .noderc*
 website/
 workspace.xml
+/.project

--- a/encoder/README.md
+++ b/encoder/README.md
@@ -39,8 +39,8 @@ API Usage
 
       // encode AIS message
       var encMsg = new AisEncode ({// class AB static info
-            msgtype    : 24,
-            part       : 2,
+            aistype    : 24,
+            part       : 1,
             mmsi       : 271041815,
             cargo      : 60,
             callsign   : "TC6163",
@@ -56,7 +56,7 @@ API Usage
 
       // encode NMEA message
       encMsg = new NmeaEncode ({ // standard class B Position report
-             msgtype    : 18,
+             msgtype    : 2,
              cog        : 72.2,
              sog        : 6.1000000000000005,
              lon        : 122.47338666666667,

--- a/encoder/lib/GG-NmeaEncode.js
+++ b/encoder/lib/GG-NmeaEncode.js
@@ -41,7 +41,7 @@ function NmeaEncode (msg) {
             this.EncodeDate();
 
             var packet =util.format ("$GPRMC,%s.00,A,%s,%s,%s,%s,%s,%s,%s,,,A"
-                , this.time, this.Dec2Min(msg.lat),lato, this.Dec2Min(msg.lon), lono, msg.sog, msg.cog, this.date);
+                , this.time, this.Dec2Min(msg.lat,2),lato, this.Dec2Min(msg.lon,3), lono, msg.sog, msg.cog, this.date);
 
             var checksum = 0; // http://rietman.wordpress.com/2008/09/25/how-to-calculate-the-nmea-checksum/
             for(var i = 1; i < packet.length; i++) {
@@ -61,14 +61,13 @@ function NmeaEncode (msg) {
 }
 
 // move from decimal notation to NMEA formating
-NmeaEncode.prototype.Dec2Min = function(cardinal){
-    // NMEA 4737.1024,N for 47°37'.1024
+NmeaEncode.prototype.Dec2Min = function(cardinal,degpadded){
+    // NMEA 4737.1024,N for 47°37'.1024 (degrees padded to 2 digits)
+    // NMEA 07620.7863,W for 76°20'.7863 W (degrees padded to 3 digits)
     if (cardinal<0) cardinal=cardinal*-1;
     var deg    = parseInt (cardinal);
     var mindec = (cardinal-deg)*60;
-    var min    = parseInt (mindec);
-    var secdec = mindec-min;
-    var card=deg*100+min+secdec;
+    var card=('00'+deg).slice(-degpadded) + ('0'+mindec.toFixed(4)).slice(-7);
 
     return (card);
 };

--- a/encoder/test/NmeaEncodeDecodeTest.js
+++ b/encoder/test/NmeaEncodeDecodeTest.js
@@ -59,10 +59,10 @@ function NmeaEncodeDecodeTest (args) {
         Track2: { // GPRMC from iphone
             cmd: 2,
             nmea: '$GPRMC,182816.26,A,4916.45,N,10342.0309,E,00.00,000.00,210115,0,0,A67',
-            lon: -123.18533333333335,
+            lon: 103.700515,
             lat: 49.274166666666666,
-            cog: 54.7,
-            sog: 0.2
+            cog: 0,
+            sog: 0
         }
 
     }


### PR DESCRIPTION
fix readme examples
fix failing unit tests

i've observed some apps misinterpreting non-padded 2 digit longitude values in the encoded $GPRMC sentences - like:
$GPRMC,165550.00,A,3732.74173,N,7620.78632,W,3.6,1.46,181027,,,A*4D

...and reading that as 762 degrees W... which is nuts.. but meh.

The NMEA standard says:

"Longitude yyyyy.yy Fixed/Variable length field:
degreesminutes.decimal - 3 fixed digits of degrees, 2 fixed
digits of minutes and a variable number of digits for
decimal-fraction of minutes. Leading zeros always
included for degrees and minutes to maintain fixed length.
The decimal point and associated decimal-fraction are
optional if full resolution is not required."

So I have adjusted the code to pad longitude degrees to 3 digits, and latitude degrees to 2 digits.
