### PR TITLE
fix: 2’s complements missing for 3 measurements

### DIFF
--- a/encoder/lib/GG-AisDecode.js
+++ b/encoder/lib/GG-AisDecode.js
@@ -530,9 +530,9 @@ function AisDecode (input, session) {
                     this.windgust      = parseInt(this.GetInt(129, 7));
                     this.winddir       = parseInt(this.GetInt(136, 9));
                     this.windgustdir   = parseInt(this.GetInt(145, 9));
-                    this.airtemp       = parseInt(this.GetInt(154, 11));
+                    this.airtemp       = parseInt(this.GetInt(154, 11, 1));
                     this.relhumid      = parseInt(this.GetInt(165, 7));
-                    this.dewpoint      = parseInt(this.GetInt(172, 10));
+                    this.dewpoint      = parseInt(this.GetInt(172, 10, 1));
                     this.airpress      = parseInt(this.GetInt(182, 9));
                     this.airpressten   = parseInt(this.GetInt(191, 2));
                     this.horvisib      = parseInt(this.GetInt(193, 8));
@@ -547,7 +547,7 @@ function AisDecode (input, session) {
                     this.swellperiod   = parseInt(this.GetInt(307, 6));
                     this.swelldir      = parseInt(this.GetInt(313, 9));
                     this.seastate      = parseInt(this.GetInt(322, 4));
-                    this.watertemp     = parseInt(this.GetInt(326, 10));
+                    this.watertemp     = parseInt(this.GetInt(326, 10, 1));
                     this.precipitation = parseInt(this.GetInt(336, 3));
                     this.salinity      = parseInt(this.GetInt(339, 9));
                     this.ice           = parseInt(this.GetInt(348, 2));

--- a/encoder/test/AisEncodeDecodeTest.js
+++ b/encoder/test/AisEncodeDecodeTest.js
@@ -238,11 +238,12 @@ function AisEncodeDecodeTest (args) {
     ,msg8_001_31: { // dac 001 fid 31 meteorological and hydrographic data
         aistype    : 800131,
         nmea       : "!AIVDM,1,1,1,B,8>h8nkP0Glr=<hFI0D6??wvlFR06EuOwgwl?wnSwe7wvlOw?sAwwnSGmwvh0,0*17",
+        mmsi       : "990000846",
         lon        : 171.5985,
         lat        : 12.2283,
-        awgwindspd : 127,
+        avgwindspd : 127,
         winddir    : 360,
-        airtemp    : 1024, 
+        airtemp    : -1024,
         watertemp  : 501
     }
     ,msg27: { // position lon range
@@ -334,7 +335,7 @@ AisEncodeDecodeTest.prototype.CheckDecode = function () {
                     this.CheckResult (test, aisTest, aisDecoded, ["mmsi", 'length', 'width', 'draught', 'shiptypeERI']);
                     break;
                 case 800131:
-                    this.CheckResult (test, aisTest, aisDecoded, ["mmsi", 'lon', 'lat', 'awgwindspd', 'winddir', 'airtemp', 'watertemp']);
+                    this.CheckResult (test, aisTest, aisDecoded, ["mmsi", 'lon', 'lat', 'avgwindspd', 'winddir', 'airtemp', 'watertemp']);
                     break;
                 case 27:
                     this.CheckResult (test, aisTest, aisDecoded, ["mmsi", 'lon', 'lat', 'cog', "sog", 'navstatus']);


### PR DESCRIPTION
There were couple of measurements missing 2’s complement.
- airtemp
- dewpoint
- watertemp

Now this is also corrected.